### PR TITLE
Fixed #9690 - filter tags by content views end envs

### DIFF
--- a/lib/hammer_cli_foreman_docker/docker_image.rb
+++ b/lib/hammer_cli_foreman_docker/docker_image.rb
@@ -1,36 +1,43 @@
-module HammerCLIForemanDocker
-  class DockerImageCommand < HammerCLIForeman::Command
-    resource :docker_images
-    command_name 'image'
-    desc _('Manage docker images')
+begin
+  require 'hammer_cli_katello'
 
-    class ListCommand < HammerCLIForeman::ListCommand
-      output do
-        field :id, _("ID")
-        field :image_id, _("Image ID")
-        field :size, _("Size")
-      end
+  module HammerCLIForemanDocker
+    class DockerImageCommand < HammerCLIForeman::Command
+      resource :docker_images
+      command_name 'image'
+      desc _('Manage docker images')
 
-      build_options do |o|
-        o.expand.including(:products, :organizations, :content_views)
-      end
-    end
+      class ListCommand < HammerCLIKatello::ListCommand
+        include ::HammerCLIKatello::LifecycleEnvironmentNameResolvable
+        output do
+          field :id, _("ID")
+          field :image_id, _("Image ID")
+          field :size, _("Size")
+        end
 
-    class InfoCommand < HammerCLIForeman::InfoCommand
-      output do
-        field :id, _("ID")
-        field :image_id, _("Image ID")
-        field :size, _("Size")
-
-        collection :tags, _("Tags") do
-          field :repository_id, _("Repository ID")
-          field :tag, _("Tag")
+        build_options do |o|
+          o.expand.including(:products, :organizations, :content_views)
         end
       end
 
-      build_options
-    end
+      class InfoCommand < HammerCLIKatello::InfoCommand
+        output do
+          field :id, _("ID")
+          field :image_id, _("Image ID")
+          field :size, _("Size")
 
-    autoload_subcommands
+          collection :tags, _("Tags") do
+            field :repository_id, _("Repository ID")
+            field :tag, _("Tag")
+          end
+        end
+
+        build_options
+      end
+
+      autoload_subcommands
+    end
   end
+rescue LoadError
+  warn _("'hammer_cli_katello' needs to be installed for %s command to work") % 'image'
 end

--- a/lib/hammer_cli_foreman_docker/docker_tag.rb
+++ b/lib/hammer_cli_foreman_docker/docker_tag.rb
@@ -1,35 +1,42 @@
-module HammerCLIForemanDocker
-  class DockerTagCommand < HammerCLIForeman::Command
-    resource :docker_tags
-    command_name 'tag'
-    desc _('Manage docker tags')
+begin
+  require 'hammer_cli_katello'
 
-    class ListCommand < HammerCLIForeman::ListCommand
-      output do
-        field :id, _("ID")
-        field :tag, _("Tag")
-        field :repository_id, _("Repository ID")
-      end
+  module HammerCLIForemanDocker
+    class DockerTagCommand < HammerCLIForeman::Command
+      resource :docker_tags
+      command_name 'tag'
+      desc _('Manage docker tags')
 
-      build_options do |o|
-        o.expand.including(:products, :organizations, :content_views)
-      end
-    end
+      class ListCommand < HammerCLIKatello::ListCommand
+        include ::HammerCLIKatello::LifecycleEnvironmentNameResolvable
+        output do
+          field :id, _("ID")
+          field :tag, _("Tag")
+          field :repository_id, _("Repository ID")
+        end
 
-    class InfoCommand < HammerCLIForeman::InfoCommand
-      output do
-        field :id, _("ID")
-        field :tag, _("Tag")
-        field :repository_id, _("Repository ID")
-
-        from :image do
-          field :id, _("Docker Image ID")
+        build_options do |o|
+          o.expand.including(:products, :organizations, :content_views)
         end
       end
 
-      build_options
-    end
+      class InfoCommand < HammerCLIKatello::InfoCommand
+        output do
+          field :id, _("ID")
+          field :tag, _("Tag")
+          field :repository_id, _("Repository ID")
 
-    autoload_subcommands
+          from :image do
+            field :id, _("Docker Image ID")
+          end
+        end
+
+        build_options
+      end
+
+      autoload_subcommands
+    end
   end
+rescue LoadError
+  warn _("'hammer_cli_katello' needs to be installed for %s command to work") % 'tag'
 end


### PR DESCRIPTION
- dependency on hammer_cli_katello introduced for image and tag commands

The diffs look bad, but the only changes are:
- commands are inherited form hammer_cli_katello to the searchables work
- module content is loada only if hammer_cli_katello is installed. We can't have direct direct dependency on the gem as these commands are conditional

Feel free to suggest better formating (resulting to cleaner diff) and/or rephrase the warning message in rescue block
