### PR TITLE
Fixes #10688 - tags and tag count added to image list

### DIFF
--- a/lib/hammer_cli_foreman_docker/docker_image.rb
+++ b/lib/hammer_cli_foreman_docker/docker_image.rb
@@ -13,6 +13,14 @@ begin
           field :id, _("ID")
           field :image_id, _("Image ID")
           field :size, _("Size")
+          field :_tag_count, _("Tag count")
+          field :_tag_list, _("Tags"), Fields::List
+        end
+
+        def extend_data(record)
+          record["_tag_list"] = (record['tags'] || []).map { |tag| tag['name'] }.uniq
+          record["_tag_count"] = record["_tag_list"].count
+          record
         end
 
         build_options do |o|
@@ -28,7 +36,7 @@ begin
 
           collection :tags, _("Tags") do
             field :repository_id, _("Repository ID")
-            field :tag, _("Tag")
+            field :name, _("Tag")
           end
         end
 


### PR DESCRIPTION
- `tags` and `tag count` fields added to `docker image list`

```
-------------------------------------|------------------------------------------------------------------|---------|-----------|-------
ID                                   | IMAGE ID                                                         | SIZE    | TAG COUNT | TAGS  
-------------------------------------|------------------------------------------------------------------|---------|-----------|-------
6d634dee-ed3d-4a26-85a8-adb4fbf51894 | df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b | 0       | 0         |       
51ec27b8-4d87-42d3-a34c-2fa355668629 | 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158 | 0       | 0         |       
4b82c125-238d-490f-bce3-b1cbc54e78fc | ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2 | 2433303 | 0         |       
22da9553-b436-489c-a2df-956202079a09 | 4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125 | 0       | 1         | latest
-------------------------------------|------------------------------------------------------------------|---------|-----------|-------
```
- tag attribute was renamed to match the data sent from API in `docker image info`
