### PR TITLE
Fixes #25874 - Shows tag info in manifest list

### DIFF
--- a/lib/hammer_cli_foreman_docker/docker_manifest.rb
+++ b/lib/hammer_cli_foreman_docker/docker_manifest.rb
@@ -15,9 +15,12 @@ begin
           field :schema_version, _("Schema Version")
           field :digest, _("Digest")
           field :downloaded, _("Downloaded"), Fields::Boolean
-          from :tag do
-            field :name, _("Tag Name")
-          end
+          field :_tags, _("Tags")
+        end
+
+        def extend_data(manifest)
+          manifest['_tags'] = manifest['tags'].map { |e| e["name"] }.join(", ")
+          manifest
         end
 
         build_options do |o|
@@ -32,9 +35,14 @@ begin
           field :schema_version, _("Schema Version")
           field :digest, _("Digest")
           field :downloaded, _("Downloaded"), Fields::Boolean
-          from :tag do
-            field :name, _("Tag Name")
+          collection :tags, _("Tags") do
+            field :name, _("Name")
           end
+        end
+
+        def extend_data(manifest)
+          manifest['_tags'] = manifest['tags'].map { |e| { name: e["name"] } }.join(", ")
+          manifest
         end
 
         build_options


### PR DESCRIPTION
Prior to this commit "hammer docker manifest list" would show empty
values in the "Tag Names" column. This is because Tags became a one to
many. i.e. manifest can have multiple tags.

This commit addresses both the "dockerr manifest list" and "docker
manifest info" cases appropriately