### PR TITLE
Fixes #27397 - lifecycle environments

### DIFF
--- a/lib/hammer_cli_foreman_docker/docker_manifest.rb
+++ b/lib/hammer_cli_foreman_docker/docker_manifest.rb
@@ -8,7 +8,8 @@ begin
       desc _('Manage docker manifests')
 
       class ListCommand < HammerCLIKatello::ListCommand
-        include ::HammerCLIKatello::LifecycleEnvironmentNameResolvable
+        include HammerCLIKatello::LifecycleEnvironmentNameMapping
+
         output do
           field :id, _("ID")
           field :name, _("Name")
@@ -26,6 +27,8 @@ begin
         build_options do |o|
           o.expand.including(:products, :organizations, :content_views)
         end
+
+        extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
       end
 
       class InfoCommand < HammerCLIKatello::InfoCommand

--- a/lib/hammer_cli_foreman_docker/docker_tag.rb
+++ b/lib/hammer_cli_foreman_docker/docker_tag.rb
@@ -8,7 +8,8 @@ begin
       desc _('Manage docker tags')
 
       class ListCommand < HammerCLIKatello::ListCommand
-        include ::HammerCLIKatello::LifecycleEnvironmentNameResolvable
+        include HammerCLIKatello::LifecycleEnvironmentNameMapping
+
         output do
           field :id, _("ID")
           field :name, _("Tag")
@@ -18,6 +19,8 @@ begin
         build_options do |o|
           o.expand.including(:products, :organizations, :content_views)
         end
+
+        extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
       end
 
       class InfoCommand < HammerCLIKatello::InfoCommand


### PR DESCRIPTION
Rename --environment options to --lifecycle-environment
to be consistent with rest of the CLI. --environment
is preserved and deprecated.