### PR TITLE
Fixes #27514, #27515 - Improved handling of foreman_docker removal

### DIFF
--- a/lib/hammer_cli_foreman_docker/docker.rb
+++ b/lib/hammer_cli_foreman_docker/docker.rb
@@ -1,5 +1,5 @@
 module HammerCLIForemanDocker
-  class DockerCommand < HammerCLIForeman::Command
+  class DockerCommand < HammerCLI::AbstractCommand
     if HammerCLIForeman.foreman_resource(:docker_manifests)
       require 'hammer_cli_foreman_docker/docker_manifest'
       subcommand 'manifest',

--- a/lib/hammer_cli_foreman_docker/docker.rb
+++ b/lib/hammer_cli_foreman_docker/docker.rb
@@ -1,6 +1,3 @@
-require 'hammer_cli_foreman_docker/docker_registry'
-require 'hammer_cli_foreman_docker/docker_container'
-
 module HammerCLIForemanDocker
   class DockerCommand < HammerCLIForeman::Command
     if HammerCLIForeman.foreman_resource(:docker_manifests)
@@ -15,11 +12,17 @@ module HammerCLIForemanDocker
                  HammerCLIForemanDocker::DockerTagCommand.desc,
                  HammerCLIForemanDocker::DockerTagCommand
     end
-    subcommand 'registry',
-               HammerCLIForemanDocker::DockerRegistryCommand.desc,
-               HammerCLIForemanDocker::DockerRegistryCommand
-    subcommand 'container',
-               HammerCLIForemanDocker::DockerContainerCommand.desc,
-               HammerCLIForemanDocker::DockerContainerCommand
+    if HammerCLIForeman.foreman_resource(:registries)
+      require 'hammer_cli_foreman_docker/docker_registry'
+      subcommand 'registry',
+                 HammerCLIForemanDocker::DockerRegistryCommand.desc,
+                 HammerCLIForemanDocker::DockerRegistryCommand
+    end
+    if HammerCLIForeman.foreman_resource(:containers)
+      require 'hammer_cli_foreman_docker/docker_container'
+      subcommand 'container',
+                 HammerCLIForemanDocker::DockerContainerCommand.desc,
+                 HammerCLIForemanDocker::DockerContainerCommand
+    end
   end
 end


### PR DESCRIPTION
Two changes:
- commands depending on resources from the foreman_docker plugin are now added conditionally
- the super-command class was updated to not check the resource it does not depend on

Do not squash the two commits on merge